### PR TITLE
Input exercise metrics into main

### DIFF
--- a/src/pages/CyclingMetrics.jsx
+++ b/src/pages/CyclingMetrics.jsx
@@ -59,6 +59,16 @@ function CyclingMetrics() {
         editingData ? setEditingData(false) : setEditingData(true)
     }
 
+    function handleClear() {
+        setDistanceIn("");
+        setElevationGainIn("");
+        setDurationIn("");
+        setAvgHeartRateIn("");
+        setMaxHeartRateIn("");
+        setBodyWeightIn("");
+        setFitnessLevelIn("");
+    }
+
     function handleSubmit() {
         if (!isError()) {
             setCyclingData(prevData => [
@@ -182,6 +192,7 @@ function CyclingMetrics() {
                             label="Distance"
                             type="number"
                             error={errors.distance}
+                            value={distanceIn}
                             onChange={(e) => setDistanceIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>Miles</InputAdornment>
@@ -193,6 +204,7 @@ function CyclingMetrics() {
                             label="Elevation Gain"
                             type="number"
                             error={errors.elevationGain}
+                            value={elevationGainIn}
                             onChange={(e) => setElevationGainIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>Feet</InputAdornment>
@@ -204,6 +216,7 @@ function CyclingMetrics() {
                             label="Duration"
                             type="number"
                             error={errors.duration}
+                            value={durationIn}
                             onChange={(e) => setDurationIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>Hours</InputAdornment>
@@ -215,6 +228,7 @@ function CyclingMetrics() {
                             label="Average Heart Rate"
                             type="number"
                             error={errors.avgHeartRate}
+                            value={avgHeartRateIn}
                             onChange={(e) => setAvgHeartRateIn(e.target.value)}
                         />
                         <TextField 
@@ -223,6 +237,7 @@ function CyclingMetrics() {
                             label="Maximum Heart Rate"
                             type="number"
                             error={errors.maxHeartRate}
+                            value={maxHeartRateIn}
                             onChange={(e) => setMaxHeartRateIn(e.target.value)}
                         />
                         <TextField 
@@ -231,6 +246,7 @@ function CyclingMetrics() {
                             label="Bodyweight"
                             type="number"
                             error={errors.bodyWeight}
+                            value={bodyWeightIn}
                             onChange={(e) => setBodyWeightIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>Kg</InputAdornment>
@@ -242,6 +258,7 @@ function CyclingMetrics() {
                             label="Fitness Level"
                             type="number"
                             error={errors.fitnessLevel}
+                            value={fitnessLevelIn}
                             onChange={(e) => setFitnessLevelIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>(0 - 2)</InputAdornment>
@@ -251,6 +268,7 @@ function CyclingMetrics() {
 
                     <Stack direction="row" justifyContent="center" spacing={5} marginTop={5}>
                         <Button variant="contained" onClick={handleSubmit}>Submit</Button>
+                        <Button variant="contained" color="secondary" onClick={handleClear}>Clear</Button>
                         <Button variant="contained" color="error" onClick={handleReset}>Reset Data</Button>
                     </Stack>
                     

--- a/src/pages/CyclingMetrics.jsx
+++ b/src/pages/CyclingMetrics.jsx
@@ -9,15 +9,25 @@ const restingHeartRates = [100, 70, 50]
 function CyclingMetrics() {
     const [editingData, setEditingData] = useState(false);
 
-    const [distanceIn, setDistanceIn] = useState(0);
-    const [elevationGainIn, setElevationGainIn] = useState(0);
-    const [durationIn, setDurationIn] = useState(0);
-    const [avgHeartRateIn, setAvgHeartRateIn] = useState(0);
-    const [maxHeartRateIn, setMaxHeartRateIn] = useState(0);
-    const [bodyWeightIn, setBodyWeightIn] = useState(0);
-    const [fitnessLevelIn, setFitnessLevelIn] = useState(0);
+    const [distanceIn, setDistanceIn] = useState(undefined);
+    const [elevationGainIn, setElevationGainIn] = useState(undefined);
+    const [durationIn, setDurationIn] = useState(undefined);
+    const [avgHeartRateIn, setAvgHeartRateIn] = useState(undefined);
+    const [maxHeartRateIn, setMaxHeartRateIn] = useState(undefined);
+    const [bodyWeightIn, setBodyWeightIn] = useState(undefined);
+    const [fitnessLevelIn, setFitnessLevelIn] = useState(undefined);
 
     const [cyclingData, setCyclingData] = useState([]);
+
+    const [errors, setErrors] = useState({
+        distance: false,
+        elevationGain: false,
+        duration: false,
+        avgHeartRate: false,
+        maxHeartRate: false,
+        bodyWeight: false,
+        fitnessLevel: false
+    })
 
     const distance = cyclingData.map(data => data.distance);
     const duration = cyclingData.map(data => data.duration);
@@ -50,18 +60,46 @@ function CyclingMetrics() {
     }
 
     function handleSubmit() {
-        setCyclingData(prevData => [
-            ...prevData,
-            {
-                distance: distanceIn,
-                elevationGain: elevationGainIn,
-                duration: durationIn,
-                avgHeartRate: avgHeartRateIn,
-                maxHeartRate: maxHeartRateIn,
-                bodyWeight: bodyWeightIn,
-                fitnessLevel: fitnessLevelIn
+        if (!isError()) {
+            setCyclingData(prevData => [
+                ...prevData,
+                {
+                    distance: distanceIn,
+                    elevationGain: elevationGainIn,
+                    duration: durationIn,
+                    avgHeartRate: avgHeartRateIn,
+                    maxHeartRate: maxHeartRateIn,
+                    bodyWeight: bodyWeightIn,
+                    fitnessLevel: fitnessLevelIn
+                }
+            ])
+        }
+    }
+
+    function isError() {
+        let newErrors = {
+            distance: (distanceIn === undefined || distanceIn < 1),
+            elevationGain: (elevationGainIn === undefined || elevationGainIn < 1),
+            duration: (durationIn === undefined || durationIn < 1),
+            avgHeartRate: (avgHeartRateIn === undefined || avgHeartRateIn < 1),
+            maxHeartRate: (maxHeartRateIn === undefined || maxHeartRateIn < 1),
+            bodyWeight: (bodyWeightIn === undefined || bodyWeightIn < 1),
+            fitnessLevel: (fitnessLevelIn === undefined || fitnessLevelIn < 0 || fitnessLevelIn > 2),
+
+        }
+
+        setErrors(newErrors);
+
+        let newErrorsArray = Object.values(newErrors)
+        let errorFound = false;
+
+        newErrorsArray.forEach(val => {
+            if (val === true) {
+                errorFound = true;
             }
-        ])
+        })
+
+        return errorFound;
     }
 
     function handleReset() {
@@ -143,6 +181,7 @@ function CyclingMetrics() {
                             variant="filled" 
                             label="Distance"
                             type="number"
+                            error={errors.distance}
                             onChange={(e) => setDistanceIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>Miles</InputAdornment>
@@ -153,6 +192,7 @@ function CyclingMetrics() {
                             variant="filled" 
                             label="Elevation Gain"
                             type="number"
+                            error={errors.elevationGain}
                             onChange={(e) => setElevationGainIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>Feet</InputAdornment>
@@ -163,6 +203,7 @@ function CyclingMetrics() {
                             variant="filled" 
                             label="Duration"
                             type="number"
+                            error={errors.duration}
                             onChange={(e) => setDurationIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>Hours</InputAdornment>
@@ -173,6 +214,7 @@ function CyclingMetrics() {
                             variant="filled" 
                             label="Average Heart Rate"
                             type="number"
+                            error={errors.avgHeartRate}
                             onChange={(e) => setAvgHeartRateIn(e.target.value)}
                         />
                         <TextField 
@@ -180,6 +222,7 @@ function CyclingMetrics() {
                             variant="filled" 
                             label="Maximum Heart Rate"
                             type="number"
+                            error={errors.maxHeartRate}
                             onChange={(e) => setMaxHeartRateIn(e.target.value)}
                         />
                         <TextField 
@@ -187,6 +230,7 @@ function CyclingMetrics() {
                             variant="filled" 
                             label="Bodyweight"
                             type="number"
+                            error={errors.bodyWeight}
                             onChange={(e) => setBodyWeightIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>Kg</InputAdornment>
@@ -197,6 +241,7 @@ function CyclingMetrics() {
                             variant="filled" 
                             label="Fitness Level"
                             type="number"
+                            error={errors.fitnessLevel}
                             onChange={(e) => setFitnessLevelIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>(0 - 2)</InputAdornment>

--- a/src/pages/CyclingMetrics.jsx
+++ b/src/pages/CyclingMetrics.jsx
@@ -71,7 +71,7 @@ const grade = elevationGain.map((data, index) => (data / (distance[index] * 5280
 const pace = duration.map((data, index) => data / distance[index]);
 
 const heartRateReserve = avgHeartRate.map((data, index) => 
-    (data - restingHeartRates[fitnessLevel[index]]) / (maxHeartRate[index] - restingHeartRates[fitnessLevel[index]]));
+    Math.abs((data - restingHeartRates[fitnessLevel[index]]) / (maxHeartRate[index] - restingHeartRates[fitnessLevel[index]])));
 
 const MET = heartRateReserve.map((data, index) => (data * (maxMETs[fitnessLevel[index]] - 1) + 1))
 

--- a/src/pages/CyclingMetrics.jsx
+++ b/src/pages/CyclingMetrics.jsx
@@ -1,86 +1,73 @@
 import { Link } from 'react-router-dom';
-import { Stack, Card, Typography } from '@mui/material';
+import { Stack, Card, Typography, Button, TextField, InputAdornment } from '@mui/material';
 import { BarChart } from '@mui/x-charts';
+import { useState } from 'react';
 
 const maxMETs = [10, 14, 18];
 const restingHeartRates = [100, 70, 50]
 
-const cyclingData = [
-    {
-        distance: 3,            // in miles
-        duration: 0.75,         // in hours
-        elevationGain: 300,     // in feet
-        avgHeartRate: 100,
-        maxHeartRate: 120,
-        bodyWeight: 70,         // in Kg
-        fitnessLevel: 0
-    },
-    {
-        distance: 5,            
-        duration: 0.75,         
-        elevationGain: 400,     
-        avgHeartRate: 105,
-        maxHeartRate: 120,
-        bodyWeight: 70,         
-        fitnessLevel: 0
-    },
-    {
-        distance: 6,            
-        duration: 1,         
-        elevationGain: 600,     
-        avgHeartRate: 115,
-        maxHeartRate: 135,
-        bodyWeight: 70,         
-        fitnessLevel: 0
-    },
-    {
-        distance: 8,            
-        duration: 1,         
-        elevationGain: 600,     
-        avgHeartRate: 105,
-        maxHeartRate: 120,
-        bodyWeight: 70,         
-        fitnessLevel: 1
-    },
-    {
-        distance: 10,            
-        duration: 1.25,         
-        elevationGain: 700,     
-        avgHeartRate: 90,
-        maxHeartRate: 110,
-        bodyWeight: 70,         
-        fitnessLevel: 2
-    },
-    
-    
-]
-
-const distance = cyclingData.map(data => data.distance);
-const duration = cyclingData.map(data => data.duration);
-const elevationGain = cyclingData.map(data => data.elevationGain);
-const avgHeartRate = cyclingData.map(data => data.avgHeartRate);
-const maxHeartRate = cyclingData.map(data => data.maxHeartRate);
-const bodyWeight = cyclingData.map(data => data.bodyWeight);
-const fitnessLevel = cyclingData.map(data => data.fitnessLevel);
-
-// grade represents the average slope steepness, it doesn't account for downhill slope
-// grade = (elevation / distance) * 100
-const grade = elevationGain.map((data, index) => (data / (distance[index] * 5280)) * 100);
-
-// pace = duration / distance
-const pace = duration.map((data, index) => data / distance[index]);
-
-const heartRateReserve = avgHeartRate.map((data, index) => 
-    Math.abs((data - restingHeartRates[fitnessLevel[index]]) / (maxHeartRate[index] - restingHeartRates[fitnessLevel[index]])));
-
-const MET = heartRateReserve.map((data, index) => (data * (maxMETs[fitnessLevel[index]] - 1) + 1))
-
-const caloriesBurned = MET.map((data, index) => parseInt(data * duration[index] * bodyWeight[index]));
-
-const labels = cyclingData.map((data, index) => `ride ${index + 1}`)
-const graphMargin = 3;
-
 function CyclingMetrics() {
+    const [editingData, setEditingData] = useState(false);
+
+    const [distanceIn, setDistanceIn] = useState(0);
+    const [elevationGainIn, setElevationGainIn] = useState(0);
+    const [durationIn, setDurationIn] = useState(0);
+    const [avgHeartRateIn, setAvgHeartRateIn] = useState(0);
+    const [maxHeartRateIn, setMaxHeartRateIn] = useState(0);
+    const [bodyWeightIn, setBodyWeightIn] = useState(0);
+    const [fitnessLevelIn, setFitnessLevelIn] = useState(0);
+
+    const [cyclingData, setCyclingData] = useState([]);
+
+    const distance = cyclingData.map(data => data.distance);
+    const duration = cyclingData.map(data => data.duration);
+    const elevationGain = cyclingData.map(data => data.elevationGain);
+    const avgHeartRate = cyclingData.map(data => data.avgHeartRate);
+    const maxHeartRate = cyclingData.map(data => data.maxHeartRate);
+    const bodyWeight = cyclingData.map(data => data.bodyWeight);
+    const fitnessLevel = cyclingData.map(data => data.fitnessLevel);
+
+    // grade represents the average slope steepness, it doesn't account for downhill slope
+    // grade = (elevation / distance) * 100
+    const grade = elevationGain.map((data, index) => (data / (distance[index] * 5280)) * 100);
+
+    // pace = duration / distance
+    const pace = duration.map((data, index) => data / distance[index]);
+
+    const heartRateReserve = avgHeartRate.map((data, index) => 
+        Math.abs((data - restingHeartRates[fitnessLevel[index]]) / (maxHeartRate[index] - restingHeartRates[fitnessLevel[index]])));
+
+    const MET = heartRateReserve.map((data, index) => (data * (maxMETs[fitnessLevel[index]] - 1) + 1))
+
+    const caloriesBurned = MET.map((data, index) => parseInt(data * duration[index] * bodyWeight[index]));
+
+    const labels = cyclingData.map((data, index) => `ride ${index + 1}`)
+    const graphMargin = 3;
+    const textInputSpacing = 3;
+
+    function handleEdit() {
+        editingData ? setEditingData(false) : setEditingData(true)
+    }
+
+    function handleSubmit() {
+        setCyclingData(prevData => [
+            ...prevData,
+            {
+                distance: distanceIn,
+                elevationGain: elevationGainIn,
+                duration: durationIn,
+                avgHeartRate: avgHeartRateIn,
+                maxHeartRate: maxHeartRateIn,
+                bodyWeight: bodyWeightIn,
+                fitnessLevel: fitnessLevelIn
+            }
+        ])
+    }
+
+    function handleReset() {
+        setCyclingData([])
+    }
+    
     return (
         <Stack>
             <Typography fontSize={32}>CYCLING METRICS</Typography>
@@ -145,7 +132,93 @@ function CyclingMetrics() {
                 </Card>
                 </Stack>
             </Stack>
-            <Link to="../fitnessTypes" className="button-link">Back to Fitness Types</Link>
+            {!editingData ? (
+                <></>
+            ) : (
+                <Card sx={{ padding:"40px", backgroundColor:"#828c85"}}>
+                    <Typography marginBottom={5} fontSize={24}>Input Cycling Metrics</Typography>
+                    <Stack direction="column" spacing={textInputSpacing}>
+                        <TextField 
+                            required
+                            variant="filled" 
+                            label="Distance"
+                            type="number"
+                            onChange={(e) => setDistanceIn(e.target.value)}
+                            InputProps={{ 
+                                endAdornment: <InputAdornment position='end'>Miles</InputAdornment>
+                                }}
+                        />
+                        <TextField 
+                            required
+                            variant="filled" 
+                            label="Elevation Gain"
+                            type="number"
+                            onChange={(e) => setElevationGainIn(e.target.value)}
+                            InputProps={{ 
+                                endAdornment: <InputAdornment position='end'>Feet</InputAdornment>
+                                }}
+                        />
+                        <TextField 
+                            required 
+                            variant="filled" 
+                            label="Duration"
+                            type="number"
+                            onChange={(e) => setDurationIn(e.target.value)}
+                            InputProps={{ 
+                                endAdornment: <InputAdornment position='end'>Hours</InputAdornment>
+                                }}
+                        />
+                        <TextField 
+                            required 
+                            variant="filled" 
+                            label="Average Heart Rate"
+                            type="number"
+                            onChange={(e) => setAvgHeartRateIn(e.target.value)}
+                        />
+                        <TextField 
+                            required 
+                            variant="filled" 
+                            label="Maximum Heart Rate"
+                            type="number"
+                            onChange={(e) => setMaxHeartRateIn(e.target.value)}
+                        />
+                        <TextField 
+                            required 
+                            variant="filled" 
+                            label="Bodyweight"
+                            type="number"
+                            onChange={(e) => setBodyWeightIn(e.target.value)}
+                            InputProps={{ 
+                                endAdornment: <InputAdornment position='end'>Kg</InputAdornment>
+                                }}
+                        />
+                        <TextField 
+                            required 
+                            variant="filled" 
+                            label="Fitness Level"
+                            type="number"
+                            onChange={(e) => setFitnessLevelIn(e.target.value)}
+                            InputProps={{ 
+                                endAdornment: <InputAdornment position='end'>(0 - 2)</InputAdornment>
+                                }}
+                        />
+                    </Stack>
+
+                    <Stack direction="row" justifyContent="center" spacing={5} marginTop={5}>
+                        <Button variant="contained" onClick={handleSubmit}>Submit</Button>
+                        <Button variant="contained" color="error" onClick={handleReset}>Reset Data</Button>
+                    </Stack>
+                    
+                </Card>
+            )}
+            <Stack direction="row" marginTop={5} spacing={5} justifyContent="center">
+                <Button variant="contained" 
+                    onClick={handleEdit}
+                >
+                    {editingData ? "Stop Editing" : "Edit Data"}
+                </Button>
+                <Link to="../fitnessTypes" className="button-link">Back to Fitness Types</Link>
+            </Stack>
         </Stack>
     );
 }

--- a/src/pages/HikingMetrics.jsx
+++ b/src/pages/HikingMetrics.jsx
@@ -1,64 +1,24 @@
 import { Link } from 'react-router-dom';
-import { Stack, Card, Typography } from '@mui/material';
+import { Stack, Card, Typography, Button, TextField, InputAdornment } from '@mui/material';
 import { BarChart } from '@mui/x-charts';
+import { useState } from 'react';
 
 const maxMETs = [10, 14, 18];
 const restingHeartRates = [100, 70, 50]
 
-const hikingData = [
-  {
-    distance: 3,          // In miles
-    elevationGain: 500,   // Elevation gain in feet
-    elevationLoss: -200,
-    duration: 1,          // In hours
-    avgHeartRate: 120,
-    maxHeartRate: 145,
-    bodyWeight: 70,       // 70Kg = 154lbs
-    fitnessLevel: 0,
-  },
-  {
-    distance: 4,          
-    elevationGain: 600,
-    elevationLoss: -200,   
-    duration: 1.25,          
-    avgHeartRate: 125,
-    maxHeartRate: 150,
-    bodyWeight: 70,       
-    fitnessLevel: 0,
-  },
-  {
-    distance: 5,          
-    elevationGain: 800,
-    elevationLoss: -300,   
-    duration: 1.25,          
-    avgHeartRate: 120,
-    maxHeartRate: 140,
-    bodyWeight: 70,       
-    fitnessLevel: 1,
-  },
-  {
-    distance: 8,          
-    elevationGain: 1000,
-    elevationLoss: -100,   
-    duration: 1.75,          
-    avgHeartRate: 115,
-    maxHeartRate: 140,
-    bodyWeight: 65,       
-    fitnessLevel: 1,
-  },
-  {
-    distance: 9.50,          
-    elevationGain: 900,
-    elevationLoss: -400,   
-    duration: 2,          
-    avgHeartRate: 125,
-    maxHeartRate: 150,
-    bodyWeight: 65,       
-    fitnessLevel: 2,
-  },
-]
+function HikingMetrics() {
+    const [editingData, setEditingData] = useState(false);
 
-function HikingMetrics() { 
+    const [distanceIn, setDistanceIn] = useState(0);
+    const [elevationGainIn, setElevationGainIn] = useState(0);
+    const [elevationLossIn, setElevationLossIn] = useState(0);
+    const [durationIn, setDurationIn] = useState(0);
+    const [avgHeartRateIn, setAvgHeartRateIn] = useState(0);
+    const [maxHeartRateIn, setMaxHeartRateIn] = useState(0);
+    const [bodyWeightIn, setBodyWeightIn] = useState(0);
+    const [fitnessLevelIn, setFitnessLevelIn] = useState(0);
+
+    const [hikingData, setHikingData] = useState([]);
 
     const distance = hikingData.map(data => data.distance);
     const elevationGain = hikingData.map(data => data.elevationGain);
@@ -85,6 +45,31 @@ function HikingMetrics() {
 
     const labels = hikingData.map((data, index) => `hike ${index + 1}`)
     const graphMargin = 3;
+    const textInputSpacing = 3;
+
+    function handleEdit() {
+        editingData ? setEditingData(false) : setEditingData(true)
+    }
+
+    function handleSubmit() {
+        setHikingData(prevData => [
+            ...prevData,
+            {
+                distance: distanceIn,
+                elevationGain: elevationGainIn,
+                elevationLoss: elevationLossIn,
+                duration: durationIn,
+                avgHeartRate: avgHeartRateIn,
+                maxHeartRate: maxHeartRateIn,
+                bodyWeight: bodyWeightIn,
+                fitnessLevel: fitnessLevelIn
+            }
+        ])
+    }
+
+    function handleReset() {
+        setHikingData([])
+    }
 
 return (
     <Stack>
@@ -148,9 +133,106 @@ return (
                         height={300}
                     />
                 </Card>
-            </Stack> 
+            </Stack>
 
-            <Link to="../fitnessTypes" className="button-link">Back to Fitness Types</Link>
+            {!editingData ? (
+                <></>
+            ) : (
+                <Card sx={{ padding:"40px", backgroundColor:"#828c85"}}>
+                    <Typography marginBottom={5} fontSize={24}>Input Hiking Metrics</Typography>
+                    <Stack direction="column" spacing={textInputSpacing}>
+                        <TextField 
+                            required
+                            variant="filled" 
+                            label="Distance"
+                            type="number"
+                            onChange={(e) => setDistanceIn(e.target.value)}
+                            InputProps={{ 
+                                endAdornment: <InputAdornment position='end'>Miles</InputAdornment>
+                                }}
+                        />
+                        <TextField 
+                            required
+                            variant="filled" 
+                            label="Elevation Gain"
+                            type="number"
+                            onChange={(e) => setElevationGainIn(e.target.value)}
+                            InputProps={{ 
+                                endAdornment: <InputAdornment position='end'>Feet</InputAdornment>
+                                }}
+                        />
+                        <TextField 
+                            required
+                            variant="filled" 
+                            label="Elevation Loss"
+                            type="number"
+                            onChange={(e) => setElevationLossIn(e.target.value)}
+                            InputProps={{ 
+                                endAdornment: <InputAdornment position='end'>Feet</InputAdornment>
+                                }}
+                        />
+                        <TextField 
+                            required 
+                            variant="filled" 
+                            label="Duration"
+                            type="number"
+                            onChange={(e) => setDurationIn(e.target.value)}
+                            InputProps={{ 
+                                endAdornment: <InputAdornment position='end'>Hours</InputAdornment>
+                                }}
+                        />
+                        <TextField 
+                            required 
+                            variant="filled" 
+                            label="Average Heart Rate"
+                            type="number"
+                            onChange={(e) => setAvgHeartRateIn(e.target.value)}
+                        />
+                        <TextField 
+                            required 
+                            variant="filled" 
+                            label="Maximum Heart Rate"
+                            type="number"
+                            onChange={(e) => setMaxHeartRateIn(e.target.value)}
+                        />
+                        <TextField 
+                            required 
+                            variant="filled" 
+                            label="Bodyweight"
+                            type="number"
+                            onChange={(e) => setBodyWeightIn(e.target.value)}
+                            InputProps={{ 
+                                endAdornment: <InputAdornment position='end'>Kg</InputAdornment>
+                                }}
+                        />
+                        <TextField 
+                            required 
+                            variant="filled" 
+                            label="Fitness Level"
+                            type="number"
+                            onChange={(e) => setFitnessLevelIn(e.target.value)}
+                            InputProps={{ 
+                                endAdornment: <InputAdornment position='end'>(0 - 2)</InputAdornment>
+                                }}
+                        />
+                    </Stack>
+
+                    <Stack direction="row" justifyContent="center" spacing={5} marginTop={5}>
+                        <Button variant="contained" onClick={handleSubmit}>Submit</Button>
+                        <Button variant="contained" color="error" onClick={handleReset}>Reset Data</Button>
+                    </Stack>
+                    
+                </Card>
+                )}
+
+            <Stack direction="row" marginTop={5} spacing={5} justifyContent="center">
+                <Button variant="contained" 
+                    onClick={handleEdit}
+                >
+                    {editingData ? "Stop Editing" : "Edit Data"}
+                </Button>
+                <Link to="../fitnessTypes" className="button-link">Back to Fitness Types</Link>
+            </Stack>
 
     </Stack>
     

--- a/src/pages/HikingMetrics.jsx
+++ b/src/pages/HikingMetrics.jsx
@@ -81,8 +81,6 @@ function HikingMetrics() {
     }
 
     function isError() {
-        // Making a new object with values equal to whether or not the input state meets certain conditions
-        // Will result in an object that holds Boolean values
         let newErrors = {
             distance: (distanceIn === undefined || distanceIn < 1),
             elevationGain: (elevationGainIn === undefined || elevationGainIn < 1),

--- a/src/pages/HikingMetrics.jsx
+++ b/src/pages/HikingMetrics.jsx
@@ -9,14 +9,14 @@ const restingHeartRates = [100, 70, 50]
 function HikingMetrics() {
     const [editingData, setEditingData] = useState(false);
 
-    const [distanceIn, setDistanceIn] = useState(0);
-    const [elevationGainIn, setElevationGainIn] = useState(0);
-    const [elevationLossIn, setElevationLossIn] = useState(0);
-    const [durationIn, setDurationIn] = useState(0);
-    const [avgHeartRateIn, setAvgHeartRateIn] = useState(0);
-    const [maxHeartRateIn, setMaxHeartRateIn] = useState(0);
-    const [bodyWeightIn, setBodyWeightIn] = useState(0);
-    const [fitnessLevelIn, setFitnessLevelIn] = useState(0);
+    const [distanceIn, setDistanceIn] = useState(undefined);
+    const [elevationGainIn, setElevationGainIn] = useState(undefined);
+    const [elevationLossIn, setElevationLossIn] = useState(undefined);
+    const [durationIn, setDurationIn] = useState(undefined);
+    const [avgHeartRateIn, setAvgHeartRateIn] = useState(undefined);
+    const [maxHeartRateIn, setMaxHeartRateIn] = useState(undefined);
+    const [bodyWeightIn, setBodyWeightIn] = useState(undefined);
+    const [fitnessLevelIn, setFitnessLevelIn] = useState(undefined);
 
     const [hikingData, setHikingData] = useState([]);
 
@@ -28,6 +28,17 @@ function HikingMetrics() {
     const maxHeartRate = hikingData.map(data => data.maxHeartRate);
     const bodyWeight = hikingData.map(data => data.bodyWeight);
     const fitnessLevel = hikingData.map(data => data.fitnessLevel);
+
+    const [errors, setErrors] = useState({
+        distance: false,
+        elevationGain: false,
+        elevationLoss: false,
+        duration: false,
+        avgHeartRate: false,
+        maxHeartRate: false,
+        bodyWeight: false,
+        fitnessLevel: false
+    })
 
     // grade represents the average slope steepness, it doesn't account for downhill slope
     // grade = (elevation / distance) * 100
@@ -52,19 +63,50 @@ function HikingMetrics() {
     }
 
     function handleSubmit() {
-        setHikingData(prevData => [
-            ...prevData,
-            {
-                distance: distanceIn,
-                elevationGain: elevationGainIn,
-                elevationLoss: elevationLossIn,
-                duration: durationIn,
-                avgHeartRate: avgHeartRateIn,
-                maxHeartRate: maxHeartRateIn,
-                bodyWeight: bodyWeightIn,
-                fitnessLevel: fitnessLevelIn
+        if (!isError()) {
+            setHikingData(prevData => [
+                ...prevData,
+                {
+                    distance: distanceIn,
+                    elevationGain: elevationGainIn,
+                    elevationLoss: elevationLossIn,
+                    duration: durationIn,
+                    avgHeartRate: avgHeartRateIn,
+                    maxHeartRate: maxHeartRateIn,
+                    bodyWeight: bodyWeightIn,
+                    fitnessLevel: fitnessLevelIn
+                }
+            ])
+        }
+    }
+
+    function isError() {
+        // Making a new object with values equal to whether or not the input state meets certain conditions
+        // Will result in an object that holds Boolean values
+        let newErrors = {
+            distance: (distanceIn === undefined || distanceIn < 1),
+            elevationGain: (elevationGainIn === undefined || elevationGainIn < 1),
+            elevationLoss: (elevationLossIn === undefined || elevationLossIn < 1),
+            duration: (durationIn === undefined || durationIn < 1),
+            avgHeartRate: (avgHeartRateIn === undefined || avgHeartRateIn < 1),
+            maxHeartRate: (maxHeartRateIn === undefined || maxHeartRateIn < 1),
+            bodyWeight: (bodyWeightIn === undefined || bodyWeightIn < 1),
+            fitnessLevel: (fitnessLevelIn === undefined || fitnessLevelIn < 0 || fitnessLevelIn > 2),
+
+        }
+
+        setErrors(newErrors);
+
+        let newErrorsArray = Object.values(newErrors)
+        let errorFound = false;
+
+        newErrorsArray.forEach(val => {
+            if (val === true) {
+                errorFound = true;
             }
-        ])
+        })
+
+        return errorFound;
     }
 
     function handleReset() {
@@ -146,6 +188,7 @@ return (
                             variant="filled" 
                             label="Distance"
                             type="number"
+                            error={errors.distance}
                             onChange={(e) => setDistanceIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>Miles</InputAdornment>
@@ -156,6 +199,7 @@ return (
                             variant="filled" 
                             label="Elevation Gain"
                             type="number"
+                            error={errors.elevationGain}
                             onChange={(e) => setElevationGainIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>Feet</InputAdornment>
@@ -166,6 +210,7 @@ return (
                             variant="filled" 
                             label="Elevation Loss"
                             type="number"
+                            error={errors.elevationLoss}
                             onChange={(e) => setElevationLossIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>Feet</InputAdornment>
@@ -176,6 +221,7 @@ return (
                             variant="filled" 
                             label="Duration"
                             type="number"
+                            error={errors.duration}
                             onChange={(e) => setDurationIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>Hours</InputAdornment>
@@ -186,6 +232,7 @@ return (
                             variant="filled" 
                             label="Average Heart Rate"
                             type="number"
+                            error={errors.avgHeartRate}
                             onChange={(e) => setAvgHeartRateIn(e.target.value)}
                         />
                         <TextField 
@@ -193,6 +240,7 @@ return (
                             variant="filled" 
                             label="Maximum Heart Rate"
                             type="number"
+                            error={errors.maxHeartRate}
                             onChange={(e) => setMaxHeartRateIn(e.target.value)}
                         />
                         <TextField 
@@ -201,6 +249,7 @@ return (
                             label="Bodyweight"
                             type="number"
                             onChange={(e) => setBodyWeightIn(e.target.value)}
+                            error={errors.bodyWeight}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>Kg</InputAdornment>
                                 }}
@@ -210,6 +259,7 @@ return (
                             variant="filled" 
                             label="Fitness Level"
                             type="number"
+                            error={errors.fitnessLevel}
                             onChange={(e) => setFitnessLevelIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>(0 - 2)</InputAdornment>

--- a/src/pages/HikingMetrics.jsx
+++ b/src/pages/HikingMetrics.jsx
@@ -77,7 +77,7 @@ function HikingMetrics() {
     const pace = duration.map((data, index) => data / distance[index]);
 
     const heartRateReserve = avgHeartRate.map((data, index) => 
-      (data - restingHeartRates[fitnessLevel[index]]) / (maxHeartRate[index] - restingHeartRates[fitnessLevel[index]]));
+      Math.abs((data - restingHeartRates[fitnessLevel[index]]) / (maxHeartRate[index] - restingHeartRates[fitnessLevel[index]])));
   
     const MET = heartRateReserve.map((data, index) => (data * (maxMETs[fitnessLevel[index]] - 1) + 1))
   

--- a/src/pages/HikingMetrics.jsx
+++ b/src/pages/HikingMetrics.jsx
@@ -62,6 +62,17 @@ function HikingMetrics() {
         editingData ? setEditingData(false) : setEditingData(true)
     }
 
+    function handleClear() {
+        setDistanceIn("");
+        setElevationGainIn("");
+        setElevationLossIn("");
+        setDurationIn("");
+        setAvgHeartRateIn("");
+        setMaxHeartRateIn("");
+        setBodyWeightIn("");
+        setFitnessLevelIn("");
+    }
+
     function handleSubmit() {
         if (!isError()) {
             setHikingData(prevData => [
@@ -187,6 +198,7 @@ return (
                             label="Distance"
                             type="number"
                             error={errors.distance}
+                            value={distanceIn}
                             onChange={(e) => setDistanceIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>Miles</InputAdornment>
@@ -198,6 +210,7 @@ return (
                             label="Elevation Gain"
                             type="number"
                             error={errors.elevationGain}
+                            value={elevationGainIn}
                             onChange={(e) => setElevationGainIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>Feet</InputAdornment>
@@ -209,6 +222,7 @@ return (
                             label="Elevation Loss"
                             type="number"
                             error={errors.elevationLoss}
+                            value={elevationLossIn}
                             onChange={(e) => setElevationLossIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>Feet</InputAdornment>
@@ -220,6 +234,7 @@ return (
                             label="Duration"
                             type="number"
                             error={errors.duration}
+                            value={durationIn}
                             onChange={(e) => setDurationIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>Hours</InputAdornment>
@@ -231,6 +246,7 @@ return (
                             label="Average Heart Rate"
                             type="number"
                             error={errors.avgHeartRate}
+                            value={avgHeartRateIn}
                             onChange={(e) => setAvgHeartRateIn(e.target.value)}
                         />
                         <TextField 
@@ -239,6 +255,7 @@ return (
                             label="Maximum Heart Rate"
                             type="number"
                             error={errors.maxHeartRate}
+                            value={maxHeartRateIn}
                             onChange={(e) => setMaxHeartRateIn(e.target.value)}
                         />
                         <TextField 
@@ -248,6 +265,7 @@ return (
                             type="number"
                             onChange={(e) => setBodyWeightIn(e.target.value)}
                             error={errors.bodyWeight}
+                            value={bodyWeightIn}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>Kg</InputAdornment>
                                 }}
@@ -258,6 +276,7 @@ return (
                             label="Fitness Level"
                             type="number"
                             error={errors.fitnessLevel}
+                            value={fitnessLevelIn}
                             onChange={(e) => setFitnessLevelIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>(0 - 2)</InputAdornment>
@@ -267,6 +286,7 @@ return (
 
                     <Stack direction="row" justifyContent="center" spacing={5} marginTop={5}>
                         <Button variant="contained" onClick={handleSubmit}>Submit</Button>
+                        <Button variant="contained" color="secondary" onClick={handleClear}>Clear</Button>
                         <Button variant="contained" color="error" onClick={handleReset}>Reset Data</Button>
                     </Stack>
                     

--- a/src/pages/RunningMetrics.jsx
+++ b/src/pages/RunningMetrics.jsx
@@ -9,15 +9,26 @@ const restingHeartRates = [100, 70, 50]
 function RunningMetrics() {
     const [editingData, setEditingData] = useState(false);
 
-    const [distanceIn, setDistanceIn] = useState(0);
-    const [durationIn, setDurationIn] = useState(0);
-    const [stepsIn, setStepsIn] = useState(0);
-    const [avgHeartRateIn, setAvgHeartRateIn] = useState(0);
-    const [maxHeartRateIn, setMaxHeartRateIn] = useState(0);
-    const [bodyWeightIn, setBodyWeightIn] = useState(0);
-    const [fitnessLevelIn, setFitnessLevelIn] = useState(0);
+    const [distanceIn, setDistanceIn] = useState(undefined);
+    const [durationIn, setDurationIn] = useState(undefined);
+    const [stepsIn, setStepsIn] = useState(undefined);
+    const [avgHeartRateIn, setAvgHeartRateIn] = useState(undefined);
+    const [maxHeartRateIn, setMaxHeartRateIn] = useState(undefined);
+    const [bodyWeightIn, setBodyWeightIn] = useState(undefined);
+    const [fitnessLevelIn, setFitnessLevelIn] = useState(undefined);
     
     const [runningData, setRunningData] = useState([]);
+
+    // This new state is accessed by the error attribute for each Textfield
+    const [errors, setErrors] = useState({
+        distance: false,
+        duration: false,
+        steps: false,
+        avgHeartRate: false,
+        maxHeartRate: false,
+        bodyWeight: false,
+        fitnessLevel: false
+    })
 
     const distance = runningData.map(data => data.distance);
     const duration = runningData.map(data => data.duration);
@@ -53,24 +64,61 @@ function RunningMetrics() {
         editingData ? setEditingData(false) : setEditingData(true)
     }
 
-
-    function handleSubmit() {
-        setRunningData(prevData => [
-            ...prevData,
-            {
-                distance: distanceIn,
-                duration: durationIn,
-                steps: stepsIn,
-                avgHeartRate: avgHeartRateIn,
-                maxHeartRate: maxHeartRateIn,
-                bodyWeight: bodyWeightIn,
-                fitnessLevel: fitnessLevelIn
-            }
-        ])
-    }
-
     function handleReset() {
         setRunningData([])
+    }
+
+    function handleSubmit() {
+        if (!isError()) {
+            setRunningData(prevData => [
+                ...prevData,
+                {
+                    distance: distanceIn,
+                    duration: durationIn,
+                    steps: stepsIn,
+                    avgHeartRate: avgHeartRateIn,
+                    maxHeartRate: maxHeartRateIn,
+                    bodyWeight: bodyWeightIn,
+                    fitnessLevel: fitnessLevelIn
+                }
+            ])
+        }
+    }
+
+    // Checking if text field input is either undefined, less than 1, or greater than the specified range
+    // If an error is found, this function returns true, preventing handleSubmit from storing the erroneous data
+    // in state.
+    function isError() {
+        // Making a new object with values equal to whether or not the input state meets certain conditions
+        // Will result in an object that holds Boolean values
+        let newErrors = {
+            distance: (distanceIn === undefined || distanceIn < 1),
+            duration: (durationIn === undefined || durationIn < 1),
+            steps: (stepsIn === undefined || stepsIn < 1),
+            avgHeartRate: (avgHeartRateIn === undefined || avgHeartRateIn < 1),
+            maxHeartRate: (maxHeartRateIn === undefined || maxHeartRateIn < 1),
+            bodyWeight: (bodyWeightIn === undefined || bodyWeightIn < 1),
+            fitnessLevel: (fitnessLevelIn === undefined || fitnessLevelIn < 0 || fitnessLevelIn > 2),
+
+        }
+
+        // Since we now have state for errors, we set it equal to the the values found within the object newErrors
+        // If any of the above conditions are true, the corresponding text field will enter an error state, indicating
+        // to the user that they entered erroneous input
+        setErrors(newErrors);
+
+        // Converting the newErrors object to a Boolean array of just the values from the newErrors object
+        let newErrorsArray = Object.values(newErrors)
+        let errorFound = false;
+
+        // Loop through the new Boolean array, setting errorFound to true if any values are true
+        newErrorsArray.forEach(val => {
+            if (val === true) {
+                errorFound = true;
+            }
+        })
+
+        return errorFound;
     }
     
 
@@ -148,26 +196,29 @@ function RunningMetrics() {
                                 variant="filled" 
                                 label="Distance"
                                 type="number"
+                                error={errors.distance}
                                 onChange={(e) => setDistanceIn(e.target.value)}
                                 InputProps={{ 
                                     endAdornment: <InputAdornment position='end'>Miles</InputAdornment>
-                                 }}
+                                }}
                             />
                             <TextField 
                                 required 
                                 variant="filled" 
                                 label="Duration"
                                 type="number"
+                                error={errors.duration}
                                 onChange={(e) => setDurationIn(e.target.value)}
                                 InputProps={{ 
                                     endAdornment: <InputAdornment position='end'>Hours</InputAdornment>
-                                 }}
+                                }}
                             />
                             <TextField 
                                 required 
                                 variant="filled" 
                                 label="Steps"
                                 type="number"
+                                error={errors.steps}
                                 onChange={(e) => setStepsIn(e.target.value)}
                             />
                             <TextField 
@@ -175,6 +226,7 @@ function RunningMetrics() {
                                 variant="filled" 
                                 label="Average Heart Rate"
                                 type="number"
+                                error={errors.avgHeartRate}
                                 onChange={(e) => setAvgHeartRateIn(e.target.value)}
                             />
                             <TextField 
@@ -182,6 +234,7 @@ function RunningMetrics() {
                                 variant="filled" 
                                 label="Maximum Heart Rate"
                                 type="number"
+                                error={errors.maxHeartRate}
                                 onChange={(e) => setMaxHeartRateIn(e.target.value)}
                             />
                             <TextField 
@@ -189,20 +242,22 @@ function RunningMetrics() {
                                 variant="filled" 
                                 label="Bodyweight"
                                 type="number"
+                                error={errors.bodyWeight}
                                 onChange={(e) => setBodyWeightIn(e.target.value)}
                                 InputProps={{ 
                                     endAdornment: <InputAdornment position='end'>Kg</InputAdornment>
-                                 }}
+                                }}
                             />
                             <TextField 
                                 required 
                                 variant="filled" 
                                 label="Fitness Level"
                                 type="number"
+                                error={errors.fitnessLevel}
                                 onChange={(e) => setFitnessLevelIn(e.target.value)}
                                 InputProps={{ 
                                     endAdornment: <InputAdornment position='end'>(0 - 2)</InputAdornment>
-                                 }}
+                                }}
                             />
                         </Stack>
                         <Stack direction="row" justifyContent="center" spacing={5} marginTop={5}>

--- a/src/pages/RunningMetrics.jsx
+++ b/src/pages/RunningMetrics.jsx
@@ -37,7 +37,7 @@ function RunningMetrics() {
     const cadence = steps.map((data, index) => data / (duration[index] * 60));
 
     const heartRateReserve = avgHeartRate.map((data, index) => 
-        (data - restingHeartRates[fitnessLevel[index]]) / (maxHeartRate[index] - restingHeartRates[fitnessLevel[index]]));
+        Math.abs((data - restingHeartRates[fitnessLevel[index]]) / (maxHeartRate[index] - restingHeartRates[fitnessLevel[index]])));
 
     const MET = heartRateReserve.map((data, index) => (data * (maxMETs[fitnessLevel[index]] - 1) + 1))
 
@@ -71,7 +71,6 @@ function RunningMetrics() {
         setRunningData([])
     }
     
-
 
     return (
         <Stack>

--- a/src/pages/RunningMetrics.jsx
+++ b/src/pages/RunningMetrics.jsx
@@ -1,88 +1,78 @@
 import { Link } from 'react-router-dom';
-import { Stack, Card, Typography } from '@mui/material';
+import { Stack, Card, Typography, Button, TextField, InputAdornment } from '@mui/material';
 import { BarChart } from '@mui/x-charts';
+import { useState } from 'react';
 
 const maxMETs = [10, 14, 18];
 const restingHeartRates = [100, 70, 50]
 
-const runningData = [
-    {
-        distance: 1.5,      // Distance ran in miles
-        duration: 0.25,      // hours
-        steps: 2500,
-        avgHeartRate: 125,
-        maxHeartRate: 145,
-        bodyWeight: 70,     // in Kg, equal to 154 lbs
-        fitnessLevel: 0
-    },
-    {
-        distance: 2,      
-        duration: 0.3,      
-        steps: 3200,
-        avgHeartRate: 130,
-        maxHeartRate: 150,
-        bodyWeight: 70,     
-        fitnessLevel: 0
-    },
-    {
-        distance: 2.5,      
-        duration: 0.35,      
-        steps: 4000,
-        avgHeartRate: 130,
-        maxHeartRate: 155,
-        bodyWeight: 70,     
-        fitnessLevel: 1
-    },
-    {
-        distance: 4,      
-        duration: 0.5,      
-        steps: 5500,
-        avgHeartRate: 125,
-        maxHeartRate: 145,
-        bodyWeight: 70,     
-        fitnessLevel: 1
-    },
-    {
-        distance: 1.5,      
-        duration: 0.5,      
-        steps: 4500,
-        avgHeartRate: 125,
-        maxHeartRate: 145,
-        bodyWeight: 70,     
-        fitnessLevel: 0
-    }
-]
-
-const distance = runningData.map(data => data.distance);
-const duration = runningData.map(data => data.duration);
-const steps = runningData.map(data => data.steps);
-const avgHeartRate = runningData.map(data => data.avgHeartRate);
-const maxHeartRate = runningData.map(data => data.maxHeartRate);
-const bodyWeight = runningData.map(data => data.bodyWeight);
-const fitnessLevel = runningData.map(data => data.fitnessLevel);
-
-// speed = distance / duration
-const speed = distance.map((data, index) => data / duration[index]);
-// pace = duration / distance
-// How long does it take to run a mile (or km if we decide to support that unit)
-const pace = duration.map((data, index) => data / distance[index]);
-// cadence = steps / minutes
-// Also known as steps per minute (SPM). Lower cadences (<160 SPM) indicates longer strides, and
-// more impact per step. This increases injury risk for beginners, so it is safer and more efficient
-// to have a cadence of 170 - 190 SPM
-const cadence = steps.map((data, index) => data / (duration[index] * 60));
-
-const heartRateReserve = avgHeartRate.map((data, index) => 
-    (data - restingHeartRates[fitnessLevel[index]]) / (maxHeartRate[index] - restingHeartRates[fitnessLevel[index]]));
-
-const MET = heartRateReserve.map((data, index) => (data * (maxMETs[fitnessLevel[index]] - 1) + 1))
-
-const caloriesBurned = MET.map((data, index) => parseInt(data * duration[index] * bodyWeight[index]));
-
-const labels = runningData.map((data, index) => `run ${index + 1}`)
-const graphMargin = 3;
-
 function RunningMetrics() {
+    const [editingData, setEditingData] = useState(false);
+    const [distanceIn, setDistanceIn] = useState(0);
+    const [durationIn, setDurationIn] = useState(0);
+    const [stepsIn, setStepsIn] = useState(0);
+    const [avgHeartRateIn, setAvgHeartRateIn] = useState(0);
+    const [maxHeartRateIn, setMaxHeartRateIn] = useState(0);
+    const [bodyWeightIn, setBodyWeightIn] = useState(0);
+    const [fitnessLevelIn, setFitnessLevelIn] = useState(0);
+    const [runningData, setRunningData] = useState([]);
+
+    const distance = runningData.map(data => data.distance);
+    const duration = runningData.map(data => data.duration);
+    const steps = runningData.map(data => data.steps);
+    const avgHeartRate = runningData.map(data => data.avgHeartRate);
+    const maxHeartRate = runningData.map(data => data.maxHeartRate);
+    const bodyWeight = runningData.map(data => data.bodyWeight);
+    const fitnessLevel = runningData.map(data => data.fitnessLevel);
+
+    // speed = distance / duration
+    const speed = distance.map((data, index) => data / duration[index]);
+    // pace = duration / distance
+    // How long does it take to run a mile (or km if we decide to support that unit)
+    const pace = duration.map((data, index) => data / distance[index]);
+    // cadence = steps / minutes
+    // Also known as steps per minute (SPM). Lower cadences (<160 SPM) indicates longer strides, and
+    // more impact per step. This increases injury risk for beginners, so it is safer and more efficient
+    // to have a cadence of 170 - 190 SPM
+    const cadence = steps.map((data, index) => data / (duration[index] * 60));
+
+    const heartRateReserve = avgHeartRate.map((data, index) => 
+        (data - restingHeartRates[fitnessLevel[index]]) / (maxHeartRate[index] - restingHeartRates[fitnessLevel[index]]));
+
+    const MET = heartRateReserve.map((data, index) => (data * (maxMETs[fitnessLevel[index]] - 1) + 1))
+
+    const caloriesBurned = MET.map((data, index) => parseInt(data * duration[index] * bodyWeight[index]));
+
+    const labels = runningData.map((data, index) => `run ${index + 1}`)
+    const graphMargin = 3;
+    const textInputSpacing = 3;
+
+    function handleEdit() {
+        editingData ? setEditingData(false) : setEditingData(true)
+    }
+
+
+    function handleSubmit() {
+        setRunningData(prevData => [
+            ...prevData,
+            {
+                distance: distanceIn,
+                duration: durationIn,
+                steps: stepsIn,
+                avgHeartRate: avgHeartRateIn,
+                maxHeartRate: maxHeartRateIn,
+                bodyWeight: bodyWeightIn,
+                fitnessLevel: fitnessLevelIn
+            }
+        ])
+    }
+
+    function handleReset() {
+        setRunningData([])
+    }
+    
+
+
     return (
         <Stack>
             <Typography fontSize={32}>
@@ -145,7 +135,91 @@ function RunningMetrics() {
                     />
                 </Card>
             </Stack>
-            <Link to="../fitnessTypes" className="button-link">Back to Fitness Types</Link>
+            <Stack>
+                {!editingData ? (
+                    <></>
+                ) : (
+                    <Card sx={{ padding:"40px", backgroundColor:"#828c85"}}>
+                        <Typography marginBottom={5} fontSize={24}>Input Running Metrics</Typography>
+                        <Stack direction="column" spacing={textInputSpacing}>
+                            <TextField 
+                                required
+                                variant="filled" 
+                                label="Distance"
+                                type="number"
+                                onChange={(e) => setDistanceIn(e.target.value)}
+                                InputProps={{ 
+                                    endAdornment: <InputAdornment position='end'>Miles</InputAdornment>
+                                 }}
+                            />
+                            <TextField 
+                                required 
+                                variant="filled" 
+                                label="Duration"
+                                type="number"
+                                onChange={(e) => setDurationIn(e.target.value)}
+                                InputProps={{ 
+                                    endAdornment: <InputAdornment position='end'>Hours</InputAdornment>
+                                 }}
+                            />
+                            <TextField 
+                                required 
+                                variant="filled" 
+                                label="Steps"
+                                type="number"
+                                onChange={(e) => setStepsIn(e.target.value)}
+                            />
+                            <TextField 
+                                required 
+                                variant="filled" 
+                                label="Average Heart Rate"
+                                type="number"
+                                onChange={(e) => setAvgHeartRateIn(e.target.value)}
+                            />
+                            <TextField 
+                                required 
+                                variant="filled" 
+                                label="Maximum Heart Rate"
+                                type="number"
+                                onChange={(e) => setMaxHeartRateIn(e.target.value)}
+                            />
+                            <TextField 
+                                required 
+                                variant="filled" 
+                                label="Bodyweight"
+                                type="number"
+                                onChange={(e) => setBodyWeightIn(e.target.value)}
+                                InputProps={{ 
+                                    endAdornment: <InputAdornment position='end'>Kg</InputAdornment>
+                                 }}
+                            />
+                            <TextField 
+                                required 
+                                variant="filled" 
+                                label="Fitness Level"
+                                type="number"
+                                onChange={(e) => setFitnessLevelIn(e.target.value)}
+                                InputProps={{ 
+                                    endAdornment: <InputAdornment position='end'>(0 - 2)</InputAdornment>
+                                 }}
+                            />
+                        </Stack>
+                        <Stack direction="row" justifyContent="center" spacing={5} marginTop={5}>
+                            <Button variant="contained" onClick={handleSubmit}>Submit</Button>
+                            <Button variant="contained" color="error" onClick={handleReset}>Reset Data</Button>
+                        </Stack>
+                    </Card>
+                )}
+            </Stack>
+            <Stack direction="row" marginTop={5} spacing={5} justifyContent="center">
+                <Button variant="contained" 
+                    onClick={handleEdit}
+                >
+                    {editingData ? "Stop Editing" : "Edit Data"}
+                </Button>
+                <Link to="../fitnessTypes" className="button-link">Back to Fitness Types</Link>
+            </Stack>
+            
         </Stack>
 
     );

--- a/src/pages/RunningMetrics.jsx
+++ b/src/pages/RunningMetrics.jsx
@@ -68,6 +68,16 @@ function RunningMetrics() {
         setRunningData([])
     }
 
+    function handleClear() {
+        setDistanceIn("");
+        setDurationIn("");
+        setStepsIn("");
+        setAvgHeartRateIn("");
+        setMaxHeartRateIn("");
+        setBodyWeightIn("");
+        setFitnessLevelIn("");
+    }
+
     function handleSubmit() {
         if (!isError()) {
             setRunningData(prevData => [
@@ -197,6 +207,7 @@ function RunningMetrics() {
                                 label="Distance"
                                 type="number"
                                 error={errors.distance}
+                                value={distanceIn}
                                 onChange={(e) => setDistanceIn(e.target.value)}
                                 InputProps={{ 
                                     endAdornment: <InputAdornment position='end'>Miles</InputAdornment>
@@ -208,6 +219,7 @@ function RunningMetrics() {
                                 label="Duration"
                                 type="number"
                                 error={errors.duration}
+                                value={durationIn}
                                 onChange={(e) => setDurationIn(e.target.value)}
                                 InputProps={{ 
                                     endAdornment: <InputAdornment position='end'>Hours</InputAdornment>
@@ -218,6 +230,7 @@ function RunningMetrics() {
                                 variant="filled" 
                                 label="Steps"
                                 type="number"
+                                value={stepsIn}
                                 error={errors.steps}
                                 onChange={(e) => setStepsIn(e.target.value)}
                             />
@@ -226,6 +239,7 @@ function RunningMetrics() {
                                 variant="filled" 
                                 label="Average Heart Rate"
                                 type="number"
+                                value={avgHeartRateIn}
                                 error={errors.avgHeartRate}
                                 onChange={(e) => setAvgHeartRateIn(e.target.value)}
                             />
@@ -234,6 +248,7 @@ function RunningMetrics() {
                                 variant="filled" 
                                 label="Maximum Heart Rate"
                                 type="number"
+                                value={maxHeartRateIn}
                                 error={errors.maxHeartRate}
                                 onChange={(e) => setMaxHeartRateIn(e.target.value)}
                             />
@@ -242,6 +257,7 @@ function RunningMetrics() {
                                 variant="filled" 
                                 label="Bodyweight"
                                 type="number"
+                                value={bodyWeightIn}
                                 error={errors.bodyWeight}
                                 onChange={(e) => setBodyWeightIn(e.target.value)}
                                 InputProps={{ 
@@ -253,6 +269,7 @@ function RunningMetrics() {
                                 variant="filled" 
                                 label="Fitness Level"
                                 type="number"
+                                value={fitnessLevelIn}
                                 error={errors.fitnessLevel}
                                 onChange={(e) => setFitnessLevelIn(e.target.value)}
                                 InputProps={{ 
@@ -262,6 +279,7 @@ function RunningMetrics() {
                         </Stack>
                         <Stack direction="row" justifyContent="center" spacing={5} marginTop={5}>
                             <Button variant="contained" onClick={handleSubmit}>Submit</Button>
+                            <Button variant="contained" color="secondary" onClick={handleClear}>Clear</Button>
                             <Button variant="contained" color="error" onClick={handleReset}>Reset Data</Button>
                         </Stack>
                     </Card>

--- a/src/pages/RunningMetrics.jsx
+++ b/src/pages/RunningMetrics.jsx
@@ -8,6 +8,7 @@ const restingHeartRates = [100, 70, 50]
 
 function RunningMetrics() {
     const [editingData, setEditingData] = useState(false);
+
     const [distanceIn, setDistanceIn] = useState(0);
     const [durationIn, setDurationIn] = useState(0);
     const [stepsIn, setStepsIn] = useState(0);
@@ -15,6 +16,7 @@ function RunningMetrics() {
     const [maxHeartRateIn, setMaxHeartRateIn] = useState(0);
     const [bodyWeightIn, setBodyWeightIn] = useState(0);
     const [fitnessLevelIn, setFitnessLevelIn] = useState(0);
+    
     const [runningData, setRunningData] = useState([]);
 
     const distance = runningData.map(data => data.distance);
@@ -113,27 +115,27 @@ function RunningMetrics() {
                     />
                 </Card>
             </Stack>
-            <Stack direction="row">
-                <Card sx={{ margin: graphMargin, backgroundColor: "#828c85",}}>
-                    <BarChart
-                        xAxis={[{ scaleType: "band", data: labels }]}
-                        series={[
-                            {data: avgHeartRate, label: "Avg Heart Rate" },
-                            {data: maxHeartRate, label: "Max Heart Rate" }
-                        ]}
-                        width={500}
-                        height={300}
-                    />
-                </Card>
-                <Card sx={{ margin: graphMargin, backgroundColor: "#828c85",}}>
-                    <BarChart
-                        xAxis={[{ scaleType: "band", data: labels }]}
-                        series={[{ data: caloriesBurned, label: "Estimated Calories Burned" }]}
-                        width={500}
-                        height={300}
-                    />
-                </Card>
-            </Stack>
+                <Stack direction="row">
+                    <Card sx={{ margin: graphMargin, backgroundColor: "#828c85",}}>
+                        <BarChart
+                            xAxis={[{ scaleType: "band", data: labels }]}
+                            series={[
+                                {data: avgHeartRate, label: "Avg Heart Rate" },
+                                {data: maxHeartRate, label: "Max Heart Rate" }
+                            ]}
+                            width={500}
+                            height={300}
+                        />
+                    </Card>
+                    <Card sx={{ margin: graphMargin, backgroundColor: "#828c85",}}>
+                        <BarChart
+                            xAxis={[{ scaleType: "band", data: labels }]}
+                            series={[{ data: caloriesBurned, label: "Estimated Calories Burned" }]}
+                            width={500}
+                            height={300}
+                        />
+                    </Card>
+                </Stack>
             <Stack>
                 {!editingData ? (
                     <></>

--- a/src/pages/SwimmingMetrics.jsx
+++ b/src/pages/SwimmingMetrics.jsx
@@ -102,6 +102,16 @@ function handleEdit() {
     editingData ? setEditingData(false) : setEditingData(true)
 }
 
+function handleClear() {
+    setLapCountIn("");
+    setLapTimesIn([]);
+    setStrokeCountIn([]);
+    setAvgHeartRateIn("");
+    setMaxHeartRateIn("");
+    setBodyWeightIn("");
+    setFitnessLevelIn("");
+}
+
 function handleSubmit() {
     if (!isError()) {
         setSwimmingData(prevData => [
@@ -135,7 +145,7 @@ function isError() {
         fitnessLevel: (fitnessLevelIn === undefined || fitnessLevelIn < 0 || fitnessLevelIn > 2),
 
     }
-    
+
     setErrors(newErrors);
 
     let newErrorsArray = Object.values(newErrors)
@@ -240,6 +250,7 @@ function handleLapCountChange(laps) {
                             label="Lap Count"
                             type="number"
                             error={errors.lapCount}
+                            value={lapCountIn}
                             onChange={(e) => handleLapCountChange(e.target.value)}
                         />
                         {/* Create N number of these text fields depending on the value of lapCount */}
@@ -251,6 +262,7 @@ function handleLapCountChange(laps) {
                                 label={`Lap Time ${index + 1}`} 
                                 type="number"
                                 error={errors.lapTime}
+                                value={lapTimesIn[index]}
                                 onChange={(e) => {
                                     const updatedLapTimes = [...lapTimesIn];
                                     updatedLapTimes[index] = parseInt(e.target.value);
@@ -269,6 +281,7 @@ function handleLapCountChange(laps) {
                                 label={`Lap ${index + 1} Stroke Count`} 
                                 type="number"
                                 error={errors.strokeCount}
+                                value={strokeCountIn[index]}
                                 onChange={(e) => {
                                     const updatedStrokeCounts = [...strokeCountIn];
                                     updatedStrokeCounts[index] = parseInt(e.target.value);
@@ -282,6 +295,7 @@ function handleLapCountChange(laps) {
                             label="Average Heart Rate"
                             type="number"
                             error={errors.avgHeartRate}
+                            value={avgHeartRateIn}
                             onChange={(e) => setAvgHeartRateIn(e.target.value)}
                         />
                         <TextField 
@@ -290,6 +304,7 @@ function handleLapCountChange(laps) {
                             label="Maximum Heart Rate"
                             type="number"
                             error={errors.maxHeartRate}
+                            value={maxHeartRateIn}
                             onChange={(e) => setMaxHeartRateIn(e.target.value)}
                         />
                         <TextField 
@@ -298,6 +313,7 @@ function handleLapCountChange(laps) {
                             label="Bodyweight"
                             type="number"
                             error={errors.bodyWeight}
+                            value={bodyWeightIn}
                             onChange={(e) => setBodyWeightIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>Kg</InputAdornment>
@@ -309,6 +325,7 @@ function handleLapCountChange(laps) {
                             label="Fitness Level"
                             type="number"
                             error={errors.fitnessLevel}
+                            value={fitnessLevelIn}
                             onChange={(e) => setFitnessLevelIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>(0 - 2)</InputAdornment>
@@ -318,6 +335,7 @@ function handleLapCountChange(laps) {
 
                     <Stack direction="row" justifyContent="center" spacing={5} marginTop={5}>
                         <Button variant="contained" onClick={handleSubmit}>Submit</Button>
+                        <Button variant="contained" color="secondary" onClick={handleClear}>Clear</Button>
                         <Button variant="contained" color="error" onClick={handleReset}>Reset Data</Button>
                     </Stack>
                     

--- a/src/pages/SwimmingMetrics.jsx
+++ b/src/pages/SwimmingMetrics.jsx
@@ -1,57 +1,23 @@
 import { Link } from 'react-router-dom';
-import { Stack, Card, Typography } from '@mui/material';
+import { Stack, Card, Typography, Button, TextField, InputAdornment } from '@mui/material';
 import { BarChart } from '@mui/x-charts';
+import { useState } from 'react';
 
 const maxMETs = [10, 14, 18];
 const restingHeartRates = [100, 70, 50]
 
-const swimmingData = [
-    {
-        lapCount: 5,                        // number of pool lengths completed, so 50 meters * lapCount = distance
-        lapTimes: [74, 76, 78, 73, 80],     // can be used to find best lap time, 
-        strokeCount: [55, 57, 57, 54, 60],  // per lap. Indicates skill, form, and experience
-        avgHeartRate: 120,
-        maxHeartRate: 130,
-        bodyWeight: 70,                     // in Kg
-        fitnessLevel: 0,
-    },
-    {
-        lapCount: 5,                        
-        lapTimes: [69, 71, 73, 68, 75],     
-        strokeCount: [48, 50, 50, 47, 53],  
-        avgHeartRate: 120,
-        maxHeartRate: 130,
-        bodyWeight: 70,                     
-        fitnessLevel: 0,
-    },
-    {
-        lapCount: 7,                        
-        lapTimes: [54, 57, 58, 53, 61, 55, 54],     
-        strokeCount: [41, 43, 43, 40, 46, 42, 40],  
-        avgHeartRate: 120,
-        maxHeartRate: 130,
-        bodyWeight: 70,                     
-        fitnessLevel: 0,
-    },
-    {
-        lapCount: 7,                        
-        lapTimes: [41, 39, 45, 43, 48, 43, 42],     
-        strokeCount: [35, 37, 37, 34, 40, 36, 34],  
-        avgHeartRate: 110,
-        maxHeartRate: 120,
-        bodyWeight: 70,                     
-        fitnessLevel: 1,
-    },
-    {
-        lapCount: 10,                        
-        lapTimes: [34, 37, 37, 33, 41, 36, 34, 31, 33, 36],     
-        strokeCount: [45, 47, 47, 44, 40, 45, 42, 44, 45],  
-        avgHeartRate: 110,
-        maxHeartRate: 125,
-        bodyWeight: 70,                     
-        fitnessLevel: 2,
-    }
-]
+function SwimmingMetrics() {
+const [editingData, setEditingData] = useState(false);
+
+const [lapCountIn, setLapCountIn] = useState(0);
+const [lapTimesIn, setLapTimesIn] = useState([]);
+const [strokeCountIn, setStrokeCountIn] = useState([]);
+const [avgHeartRateIn, setAvgHeartRateIn] = useState(0);
+const [maxHeartRateIn, setMaxHeartRateIn] = useState(0);
+const [bodyWeightIn, setBodyWeightIn] = useState(0);
+const [fitnessLevelIn, setFitnessLevelIn] = useState(0);
+
+const [swimmingData, setSwimmingData] = useState([]);
 
 const lapCount = swimmingData.map(data => data.lapCount);
 const lapTimes = swimmingData.map(data => data.lapTimes);
@@ -66,7 +32,7 @@ const fitnessLevel = swimmingData.map(data => data.fitnessLevel);
 const duration = lapTimes.map(data => {
     return (data.reduce(
         (accumulator, currentValue) => accumulator + currentValue, 0
-    ) / 60 )
+    ) / 60)
 })
 
 // Finding the strokes per swim by totaling the strokes for each lap per swim
@@ -75,6 +41,7 @@ const strokesPerSwim = strokeCount.map(data => {
         (accumulator, currentValue) => accumulator + currentValue, 0
     ))
 })
+
 
 // Finding the strokes per minute
 // strokeRate = strokesPerSwim / minutes per swim
@@ -94,7 +61,10 @@ lapTimes.map((data, index) => {
 })
 
 // Transpose the array. Ex: a 5 x 3 array would become a 3 x 5. Useful for stacking the data using MUI X
-const transposed = lapTimes[longestLapIdx].map((data, colIndex) => lapTimes.map(row => row[colIndex]));
+let transposed = [];
+if (lapTimes.length > 0) {
+    transposed = lapTimes[longestLapIdx].map((data, colIndex) => lapTimes.map(row => row[colIndex]));
+}
 
 
 // Creating an array of objects with "data" and "label", this is the format MUI X Charts accepts
@@ -114,10 +84,46 @@ const MET = heartRateReserve.map((data, index) => (data * (maxMETs[fitnessLevel[
 
 const caloriesBurned = MET.map((data, index) => parseInt(data * (duration[index] / 60) * bodyWeight[index]));
 
-const labels = swimmingData.map((data, index) => `swim ${index + 1}`)
+const labels = swimmingData.map((_, index) => `swim ${index + 1}`)
 const graphMargin = 3;
+const textInputSpacing = 3;
 
-function SwimmingMetrics() {
+function handleEdit() {
+    editingData ? setEditingData(false) : setEditingData(true)
+}
+
+function handleSubmit() {
+    setSwimmingData(prevData => [
+        ...prevData,
+        {
+            lapCount: lapCountIn,
+            lapTimes: lapTimesIn,
+            strokeCount: strokeCountIn,
+            avgHeartRate: avgHeartRateIn,
+            maxHeartRate: maxHeartRateIn,
+            bodyWeight: bodyWeightIn,
+            fitnessLevel: fitnessLevelIn
+        }
+    ])
+}
+
+function handleReset() {
+    setSwimmingData([])
+}
+
+function handleLapCountChange(laps) {
+    const count = parseInt(laps);
+    setLapCountIn(count);
+    // When you input a value for the lap count, arrays for lap times and stroke count are created
+    // They are filled with empty strings based on the value of count
+    // This allows us to map over these empty arrays, creating text fields for each element
+    // Example:
+    // If lapTimesIn = ["", "", ""]
+    // Then three text fields are created to input into.
+    setLapTimesIn(new Array(count).fill(""));
+    setStrokeCountIn(new Array(count).fill(""));
+}
+
     return (
         <Stack>
             <Typography fontSize={32}>SWIMMING METRICS</Typography>
@@ -179,8 +185,103 @@ function SwimmingMetrics() {
                         />
                     </Card>
                 </Stack>
+                {!editingData ? (
+                    <></>
+                ) : (
+                    <Card sx={{ padding:"40px", backgroundColor:"#828c85"}}>
+                    <Typography marginBottom={5} fontSize={24}>Input Swimming Metrics</Typography>
+                    <Stack direction="column" spacing={textInputSpacing}>
+                        <TextField 
+                            required
+                            variant="filled" 
+                            label="Lap Count"
+                            type="number"
+                            onChange={(e) => handleLapCountChange(e.target.value)}
+                        />
+                        {/* Create N number of these text fields depending on the value of lapCount */}
+                        {lapTimesIn.map((_, index) => (
+                            <TextField 
+                                key={index}
+                                required
+                                variant="filled" 
+                                label={`Lap Time ${index + 1}`} 
+                                type="number"
+                                onChange={(e) => {
+                                    const updatedLapTimes = [...lapTimesIn];
+                                    updatedLapTimes[index] = parseInt(e.target.value);
+                                    setLapTimesIn(updatedLapTimes);
+                                }}
+                                InputProps={{ 
+                                    endAdornment: <InputAdornment position='end'>Seconds</InputAdornment>
+                                }}
+                            />
+                        ))}
+                        {strokeCountIn.map((_, index) => (
+                            <TextField 
+                                key={index}
+                                required
+                                variant="filled" 
+                                label={`Lap ${index + 1} Stroke Count`} 
+                                type="number"
+                                onChange={(e) => {
+                                    const updatedStrokeCounts = [...strokeCountIn];
+                                    updatedStrokeCounts[index] = parseInt(e.target.value);
+                                    setStrokeCountIn(updatedStrokeCounts);
+                                }}
+                            />
+                        ))}
+                        <TextField 
+                            required 
+                            variant="filled" 
+                            label="Average Heart Rate"
+                            type="number"
+                            onChange={(e) => setAvgHeartRateIn(e.target.value)}
+                        />
+                        <TextField 
+                            required 
+                            variant="filled" 
+                            label="Maximum Heart Rate"
+                            type="number"
+                            onChange={(e) => setMaxHeartRateIn(e.target.value)}
+                        />
+                        <TextField 
+                            required 
+                            variant="filled" 
+                            label="Bodyweight"
+                            type="number"
+                            onChange={(e) => setBodyWeightIn(e.target.value)}
+                            InputProps={{ 
+                                endAdornment: <InputAdornment position='end'>Kg</InputAdornment>
+                                }}
+                        />
+                        <TextField 
+                            required 
+                            variant="filled" 
+                            label="Fitness Level"
+                            type="number"
+                            onChange={(e) => setFitnessLevelIn(e.target.value)}
+                            InputProps={{ 
+                                endAdornment: <InputAdornment position='end'>(0 - 2)</InputAdornment>
+                                }}
+                        />
+                    </Stack>
+
+                    <Stack direction="row" justifyContent="center" spacing={5} marginTop={5}>
+                        <Button variant="contained" onClick={handleSubmit}>Submit</Button>
+                        <Button variant="contained" color="error" onClick={handleReset}>Reset Data</Button>
+                    </Stack>
+                    
+                </Card>
+                )}
             </Stack>
-            <Link to="../fitnessTypes" className="button-link">Back to Fitness Types</Link>
+            <Stack direction="row" marginTop={5} spacing={5} justifyContent="center">
+                <Button variant="contained" 
+                    onClick={handleEdit}
+                >
+                    {editingData ? "Stop Editing" : "Edit Data"}
+                </Button>
+                <Link to="../fitnessTypes" className="button-link">Back to Fitness Types</Link>
+            </Stack>
         </Stack>
     );
 

--- a/src/pages/SwimmingMetrics.jsx
+++ b/src/pages/SwimmingMetrics.jsx
@@ -108,7 +108,7 @@ const result = transposed.map((data, index) => ({
 const distance = lapCount.map(data => data * 50);
 
 const heartRateReserve = avgHeartRate.map((data, index) => 
-    (data - restingHeartRates[fitnessLevel[index]]) / (maxHeartRate[index] - restingHeartRates[fitnessLevel[index]]));
+    Math.abs((data - restingHeartRates[fitnessLevel[index]]) / (maxHeartRate[index] - restingHeartRates[fitnessLevel[index]])));
 
 const MET = heartRateReserve.map((data, index) => (data * (maxMETs[fitnessLevel[index]] - 1) + 1))
 

--- a/src/pages/SwimmingMetrics.jsx
+++ b/src/pages/SwimmingMetrics.jsx
@@ -9,15 +9,25 @@ const restingHeartRates = [100, 70, 50]
 function SwimmingMetrics() {
 const [editingData, setEditingData] = useState(false);
 
-const [lapCountIn, setLapCountIn] = useState(0);
+const [lapCountIn, setLapCountIn] = useState(undefined);
 const [lapTimesIn, setLapTimesIn] = useState([]);
 const [strokeCountIn, setStrokeCountIn] = useState([]);
-const [avgHeartRateIn, setAvgHeartRateIn] = useState(0);
-const [maxHeartRateIn, setMaxHeartRateIn] = useState(0);
-const [bodyWeightIn, setBodyWeightIn] = useState(0);
-const [fitnessLevelIn, setFitnessLevelIn] = useState(0);
+const [avgHeartRateIn, setAvgHeartRateIn] = useState(undefined);
+const [maxHeartRateIn, setMaxHeartRateIn] = useState(undefined);
+const [bodyWeightIn, setBodyWeightIn] = useState(undefined);
+const [fitnessLevelIn, setFitnessLevelIn] = useState(undefined);
 
 const [swimmingData, setSwimmingData] = useState([]);
+
+const [errors, setErrors] = useState({
+    lapCount: false,
+    lapTime: false,
+    strokeCount: false,
+    avgHeartRate: false,
+    maxHeartRate: false,
+    bodyWeight: false,
+    fitnessLevel: false
+})
 
 const lapCount = swimmingData.map(data => data.lapCount);
 const lapTimes = swimmingData.map(data => data.lapTimes);
@@ -93,18 +103,51 @@ function handleEdit() {
 }
 
 function handleSubmit() {
-    setSwimmingData(prevData => [
-        ...prevData,
-        {
-            lapCount: lapCountIn,
-            lapTimes: lapTimesIn,
-            strokeCount: strokeCountIn,
-            avgHeartRate: avgHeartRateIn,
-            maxHeartRate: maxHeartRateIn,
-            bodyWeight: bodyWeightIn,
-            fitnessLevel: fitnessLevelIn
+    if (!isError()) {
+        setSwimmingData(prevData => [
+            ...prevData,
+            {
+                lapCount: lapCountIn,
+                lapTimes: lapTimesIn,
+                strokeCount: strokeCountIn,
+                avgHeartRate: avgHeartRateIn,
+                maxHeartRate: maxHeartRateIn,
+                bodyWeight: bodyWeightIn,
+                fitnessLevel: fitnessLevelIn
+            }
+        ])
+    }
+}
+
+// This function was the first time I used the some method, so I'm going to document it for my sake.
+// The some() method of Array instances tests whether at least one element in the array
+// passes the test implemented by the provided function. It returns true if, in the array,
+// it finds an element for which the provided function returns true; otherwise it returns
+// false. It doesn't modify the array. 
+function isError() {
+    let newErrors = {
+        lapCount: (lapCountIn === undefined || lapCountIn < 1),
+        lapTime: lapTimesIn.some(val => val === undefined || val < 1),
+        strokeCount: strokeCountIn.some(val => val === undefined || val < 1),
+        avgHeartRate: (avgHeartRateIn === undefined || avgHeartRateIn < 1),
+        maxHeartRate: (maxHeartRateIn === undefined || maxHeartRateIn < 1),
+        bodyWeight: (bodyWeightIn === undefined || bodyWeightIn < 1),
+        fitnessLevel: (fitnessLevelIn === undefined || fitnessLevelIn < 0 || fitnessLevelIn > 2),
+
+    }
+    
+    setErrors(newErrors);
+
+    let newErrorsArray = Object.values(newErrors)
+    let errorFound = false;
+
+    newErrorsArray.forEach(val => {
+        if (val === true) {
+            errorFound = true;
         }
-    ])
+    })
+
+    return errorFound;
 }
 
 function handleReset() {
@@ -196,6 +239,7 @@ function handleLapCountChange(laps) {
                             variant="filled" 
                             label="Lap Count"
                             type="number"
+                            error={errors.lapCount}
                             onChange={(e) => handleLapCountChange(e.target.value)}
                         />
                         {/* Create N number of these text fields depending on the value of lapCount */}
@@ -206,6 +250,7 @@ function handleLapCountChange(laps) {
                                 variant="filled" 
                                 label={`Lap Time ${index + 1}`} 
                                 type="number"
+                                error={errors.lapTime}
                                 onChange={(e) => {
                                     const updatedLapTimes = [...lapTimesIn];
                                     updatedLapTimes[index] = parseInt(e.target.value);
@@ -223,6 +268,7 @@ function handleLapCountChange(laps) {
                                 variant="filled" 
                                 label={`Lap ${index + 1} Stroke Count`} 
                                 type="number"
+                                error={errors.strokeCount}
                                 onChange={(e) => {
                                     const updatedStrokeCounts = [...strokeCountIn];
                                     updatedStrokeCounts[index] = parseInt(e.target.value);
@@ -235,6 +281,7 @@ function handleLapCountChange(laps) {
                             variant="filled" 
                             label="Average Heart Rate"
                             type="number"
+                            error={errors.avgHeartRate}
                             onChange={(e) => setAvgHeartRateIn(e.target.value)}
                         />
                         <TextField 
@@ -242,6 +289,7 @@ function handleLapCountChange(laps) {
                             variant="filled" 
                             label="Maximum Heart Rate"
                             type="number"
+                            error={errors.maxHeartRate}
                             onChange={(e) => setMaxHeartRateIn(e.target.value)}
                         />
                         <TextField 
@@ -249,6 +297,7 @@ function handleLapCountChange(laps) {
                             variant="filled" 
                             label="Bodyweight"
                             type="number"
+                            error={errors.bodyWeight}
                             onChange={(e) => setBodyWeightIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>Kg</InputAdornment>
@@ -259,6 +308,7 @@ function handleLapCountChange(laps) {
                             variant="filled" 
                             label="Fitness Level"
                             type="number"
+                            error={errors.fitnessLevel}
                             onChange={(e) => setFitnessLevelIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>(0 - 2)</InputAdornment>

--- a/src/pages/WeightLiftingMetrics.jsx
+++ b/src/pages/WeightLiftingMetrics.jsx
@@ -113,7 +113,7 @@ function WeightLiftingMetrics() {
     // A value of 50% indicates you were exercising at 50% of your heart rate reserve
     // Important for calculating the estimated calories burnt during a workout.
     const heartRateReserve = avgHeartRate.map((data, index) => 
-        (data - restingHeartRates[fitnessLevel[index]]) / (maxHeartRate[index] - restingHeartRates[fitnessLevel[index]]));
+        Math.abs((data - restingHeartRates[fitnessLevel[index]]) / (maxHeartRate[index] - restingHeartRates[fitnessLevel[index]])));
 
     // MET = (heartRateReserve * (maxMET - 1)) + 1
     // MET was explained earlier in the documentation, it is crucial for estimating calories burnt

--- a/src/pages/WeightLiftingMetrics.jsx
+++ b/src/pages/WeightLiftingMetrics.jsx
@@ -23,16 +23,27 @@ const restingHeartRates = [100, 70, 50]
 function WeightLiftingMetrics() {
     const [editingData, setEditingData] = useState(false);
 
-    const [repsIn, setRepsIn] = useState(0);
-    const [setsIn, setSetsIn] = useState(0);
-    const [weightOfWeightsIn, setWeightOfWeightsIn] = useState(0);
-    const [durationIn, setDurationIn] = useState(0);
-    const [avgHeartRateIn, setAvgHeartRateIn] = useState(0);
-    const [maxHeartRateIn, setMaxHeartRateIn] = useState(0);
-    const [bodyWeightIn, setBodyWeightIn] = useState(0);
-    const [fitnessLevelIn, setFitnessLevelIn] = useState(0);
+    const [repsIn, setRepsIn] = useState(undefined);
+    const [setsIn, setSetsIn] = useState(undefined);
+    const [weightOfWeightsIn, setWeightOfWeightsIn] = useState(undefined);
+    const [durationIn, setDurationIn] = useState(undefined);
+    const [avgHeartRateIn, setAvgHeartRateIn] = useState(undefined);
+    const [maxHeartRateIn, setMaxHeartRateIn] = useState(undefined);
+    const [bodyWeightIn, setBodyWeightIn] = useState(undefined);
+    const [fitnessLevelIn, setFitnessLevelIn] = useState(undefined);
 
     const [weightLiftData, setWeightLiftData] = useState([]);
+
+    const [errors, setErrors] = useState({
+        reps: false,
+        sets: false,
+        weightOfWeights: false,
+        duration: false,
+        avgHeartRate: false,
+        maxHeartRate: false,
+        bodyWeight: false,
+        fitnessLevel: false
+    })
 
     const reps = weightLiftData.map(data => data.reps);
     const sets = weightLiftData.map(data => data.sets);
@@ -83,19 +94,48 @@ function WeightLiftingMetrics() {
     }
 
     function handleSubmit() {
-        setWeightLiftData(prevData => [
-            ...prevData,
-            {
-                reps: repsIn,
-                sets: setsIn,
-                weightOfWeights: weightOfWeightsIn,
-                duration: durationIn,
-                avgHeartRate: avgHeartRateIn,
-                maxHeartRate: maxHeartRateIn,
-                bodyWeight: bodyWeightIn,
-                fitnessLevel: fitnessLevelIn
+        if (!isError()) {
+            setWeightLiftData(prevData => [
+                ...prevData,
+                {
+                    reps: repsIn,
+                    sets: setsIn,
+                    weightOfWeights: weightOfWeightsIn,
+                    duration: durationIn,
+                    avgHeartRate: avgHeartRateIn,
+                    maxHeartRate: maxHeartRateIn,
+                    bodyWeight: bodyWeightIn,
+                    fitnessLevel: fitnessLevelIn
+                }
+            ])
+        }
+    }
+
+    function isError() {
+        let newErrors = {
+            reps: (repsIn === undefined || repsIn < 1),
+            sets: (setsIn === undefined || setsIn < 1),
+            weightOfWeights: (weightOfWeightsIn === undefined || weightOfWeightsIn < 1),
+            duration: (durationIn === undefined || durationIn < 1),
+            avgHeartRate: (avgHeartRateIn === undefined || avgHeartRateIn < 1),
+            maxHeartRate: (maxHeartRateIn === undefined || maxHeartRateIn < 1),
+            bodyWeight: (bodyWeightIn === undefined || bodyWeightIn < 1),
+            fitnessLevel: (fitnessLevelIn === undefined || fitnessLevelIn < 0 || fitnessLevelIn > 2),
+
+        }
+
+        setErrors(newErrors);
+
+        let newErrorsArray = Object.values(newErrors)
+        let errorFound = false;
+
+        newErrorsArray.forEach(val => {
+            if (val === true) {
+                errorFound = true;
             }
-        ])
+        })
+
+        return errorFound;
     }
 
     function handleReset() {
@@ -175,6 +215,7 @@ function WeightLiftingMetrics() {
                             variant="filled" 
                             label="Reps"
                             type="number"
+                            error={errors.reps}
                             onChange={(e) => setRepsIn(e.target.value)}
                         />
                         <TextField 
@@ -182,6 +223,7 @@ function WeightLiftingMetrics() {
                             variant="filled" 
                             label="Sets"
                             type="number"
+                            error={errors.sets}
                             onChange={(e) => setSetsIn(e.target.value)}
                         />
                         <TextField 
@@ -189,6 +231,7 @@ function WeightLiftingMetrics() {
                             variant="filled" 
                             label="Weight of Weights"
                             type="number"
+                            error={errors.weightOfWeights}
                             onChange={(e) => setWeightOfWeightsIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>Kg</InputAdornment>
@@ -199,6 +242,7 @@ function WeightLiftingMetrics() {
                             variant="filled" 
                             label="Duration"
                             type="number"
+                            error={errors.duration}
                             onChange={(e) => setDurationIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>Hours</InputAdornment>
@@ -209,6 +253,7 @@ function WeightLiftingMetrics() {
                             variant="filled" 
                             label="Average Heart Rate"
                             type="number"
+                            error={errors.avgHeartRate}
                             onChange={(e) => setAvgHeartRateIn(e.target.value)}
                         />
                         <TextField 
@@ -216,6 +261,7 @@ function WeightLiftingMetrics() {
                             variant="filled" 
                             label="Maximum Heart Rate"
                             type="number"
+                            error={errors.maxHeartRate}
                             onChange={(e) => setMaxHeartRateIn(e.target.value)}
                         />
                         <TextField 
@@ -223,6 +269,7 @@ function WeightLiftingMetrics() {
                             variant="filled" 
                             label="Bodyweight"
                             type="number"
+                            error={errors.bodyWeight}
                             onChange={(e) => setBodyWeightIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>Kg</InputAdornment>
@@ -233,6 +280,7 @@ function WeightLiftingMetrics() {
                             variant="filled" 
                             label="Fitness Level"
                             type="number"
+                            error={errors.fitnessLevel}
                             onChange={(e) => setFitnessLevelIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>(0 - 2)</InputAdornment>

--- a/src/pages/WeightLiftingMetrics.jsx
+++ b/src/pages/WeightLiftingMetrics.jsx
@@ -93,6 +93,17 @@ function WeightLiftingMetrics() {
         editingData ? setEditingData(false) : setEditingData(true)
     }
 
+    function handleClear() {
+        setRepsIn("");
+        setSetsIn("");
+        setWeightOfWeightsIn("");
+        setDurationIn("");
+        setAvgHeartRateIn("");
+        setMaxHeartRateIn("");
+        setBodyWeightIn("");
+        setFitnessLevelIn("");
+    }
+
     function handleSubmit() {
         if (!isError()) {
             setWeightLiftData(prevData => [
@@ -216,6 +227,7 @@ function WeightLiftingMetrics() {
                             label="Reps"
                             type="number"
                             error={errors.reps}
+                            value={repsIn}
                             onChange={(e) => setRepsIn(e.target.value)}
                         />
                         <TextField 
@@ -224,6 +236,7 @@ function WeightLiftingMetrics() {
                             label="Sets"
                             type="number"
                             error={errors.sets}
+                            value={setsIn}
                             onChange={(e) => setSetsIn(e.target.value)}
                         />
                         <TextField 
@@ -232,6 +245,7 @@ function WeightLiftingMetrics() {
                             label="Weight of Weights"
                             type="number"
                             error={errors.weightOfWeights}
+                            value={weightOfWeightsIn}
                             onChange={(e) => setWeightOfWeightsIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>Kg</InputAdornment>
@@ -243,6 +257,7 @@ function WeightLiftingMetrics() {
                             label="Duration"
                             type="number"
                             error={errors.duration}
+                            value={durationIn}
                             onChange={(e) => setDurationIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>Hours</InputAdornment>
@@ -254,6 +269,7 @@ function WeightLiftingMetrics() {
                             label="Average Heart Rate"
                             type="number"
                             error={errors.avgHeartRate}
+                            value={avgHeartRateIn}
                             onChange={(e) => setAvgHeartRateIn(e.target.value)}
                         />
                         <TextField 
@@ -262,6 +278,7 @@ function WeightLiftingMetrics() {
                             label="Maximum Heart Rate"
                             type="number"
                             error={errors.maxHeartRate}
+                            value={maxHeartRateIn}
                             onChange={(e) => setMaxHeartRateIn(e.target.value)}
                         />
                         <TextField 
@@ -270,6 +287,7 @@ function WeightLiftingMetrics() {
                             label="Bodyweight"
                             type="number"
                             error={errors.bodyWeight}
+                            value={bodyWeightIn}
                             onChange={(e) => setBodyWeightIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>Kg</InputAdornment>
@@ -281,6 +299,7 @@ function WeightLiftingMetrics() {
                             label="Fitness Level"
                             type="number"
                             error={errors.fitnessLevel}
+                            value={fitnessLevelIn}
                             onChange={(e) => setFitnessLevelIn(e.target.value)}
                             InputProps={{ 
                                 endAdornment: <InputAdornment position='end'>(0 - 2)</InputAdornment>
@@ -290,6 +309,7 @@ function WeightLiftingMetrics() {
 
                     <Stack direction="row" justifyContent="center" spacing={5} marginTop={5}>
                         <Button variant="contained" onClick={handleSubmit}>Submit</Button>
+                        <Button variant="contained" color="secondary" onClick={handleClear}>Clear</Button>
                         <Button variant="contained" color="error" onClick={handleReset}>Reset Data</Button>
                     </Stack>
                     

--- a/src/pages/WeightLiftingMetrics.jsx
+++ b/src/pages/WeightLiftingMetrics.jsx
@@ -1,8 +1,7 @@
 import { Link } from 'react-router-dom';
-import { Stack, Card, Typography } from '@mui/material';
+import { Stack, Card, Typography, Button, TextField, InputAdornment } from '@mui/material';
 import { BarChart } from '@mui/x-charts';
-
-// Here I am declaring some sample data for weight lifting:
+import { useState } from 'react';
 
 // MET (Metabolic Equivalent of Task) is defined as the energy expenditure for a given task
 // An MET of 1 is measured as the energy expenditure at rest. 
@@ -21,76 +20,29 @@ const maxMETs = [10, 14, 18];
 // 2 - Highly Trained Atheletes: 50
 const restingHeartRates = [100, 70, 50]
 
-// Imagine this data represents someone who is continually improving at weight lifting
-const weightLiftData = [
-    {
-        reps: 15,
-        sets: 2,
-        weightOfWeights: 5,     // in Kg
-        bodyWeight: 70,         // also in Kg, equal to about 154 pounds
-        age: 20,                // will come in handy later on to calculate max heart rates (220 - age)
-        avgHeartRate: 125,      // average heart rate over the duration of the exercise (BPM)
-        maxHeartRate: 156,      // maximum heart rate, not sustained over the duration of the exercise (just peak)
-        duration: 0.25,         // duration of exercise in hours (useful for various calculations)
-        fitnessLevel: 0,        // from 0 to 2, these values index the array of max MET values
-    }, 
-    {
-        reps: 20,               // 5 more reps per set
-        sets: 4,                // Double the sets
-        weightOfWeights: 7.5,
-        bodyWeight: 70,
-        age: 20,
-        avgHeartRate: 125,
-        maxHeartRate: 160,
-        duration: 0.50,         // Therefore, double the duration
-        fitnessLevel: 0,
-    },
-    {
-        reps: 25,               // 5 more reps per set
-        sets: 4,
-        weightOfWeights: 7.5,
-        bodyWeight: 75,
-        age: 20,
-        avgHeartRate: 115,
-        maxHeartRate: 145,
-        duration: 0.60,
-        fitnessLevel: 1,        // Now in better shape
-    }, 
-    {
-        reps: 30,               // More reps
-        sets: 4,
-        weightOfWeights: 7.5,
-        bodyWeight: 75,
-        age: 20,            
-        avgHeartRate: 120,
-        maxHeartRate: 150,
-        duration: 0.50,         // Now they are faster, even with more reps
-        fitnessLevel: 1
-    }, 
-    {
-        reps: 30,
-        sets: 5,
-        weightOfWeights: 10,    // Heavier weights
-        bodyWeight: 80,         // More muscle mass
-        age: 21,                // A year has passed
-        avgHeartRate: 125,
-        maxHeartRate: 158,
-        duration: 0.65,         // Heavier weights take longer
-        fitnessLevel: 2         // Now considered a professional weight lifter (usually takes longer than this but oh well)
-    }
-]
-// Eventually we should allow users to input this data, but I want to keep things simple for now
-
 function WeightLiftingMetrics() {
-    // Pulling individual data from the objects in weightLiftData into their own arrays
+    const [editingData, setEditingData] = useState(false);
+
+    const [repsIn, setRepsIn] = useState(0);
+    const [setsIn, setSetsIn] = useState(0);
+    const [weightOfWeightsIn, setWeightOfWeightsIn] = useState(0);
+    const [durationIn, setDurationIn] = useState(0);
+    const [avgHeartRateIn, setAvgHeartRateIn] = useState(0);
+    const [maxHeartRateIn, setMaxHeartRateIn] = useState(0);
+    const [bodyWeightIn, setBodyWeightIn] = useState(0);
+    const [fitnessLevelIn, setFitnessLevelIn] = useState(0);
+
+    const [weightLiftData, setWeightLiftData] = useState([]);
+
     const reps = weightLiftData.map(data => data.reps);
     const sets = weightLiftData.map(data => data.sets);
     const weightOfWeights = weightLiftData.map(data => data.weightOfWeights);
-    const bodyWeight = weightLiftData.map(data => data.bodyWeight);
+    const duration = weightLiftData.map(data => data.duration);
     const avgHeartRate = weightLiftData.map(data => data.avgHeartRate);
     const maxHeartRate = weightLiftData.map(data => data.maxHeartRate);
+    const bodyWeight = weightLiftData.map(data => data.bodyWeight);
     const fitnessLevel = weightLiftData.map(data => data.fitnessLevel);
-    const duration = weightLiftData.map(data => data.duration);
+    
 
     // totalReps = reps * sets
     const totalReps = reps.map((data, index) => data * sets[index]);
@@ -123,16 +75,33 @@ function WeightLiftingMetrics() {
     const caloriesBurned = MET.map((data, index) => parseInt(data * duration[index] * bodyWeight[index]));
 
     const labels = weightLiftData.map((_, index) => `Session ${index + 1}`);
-
     const graphMargin = 3;
+    const textInputSpacing = 3;
 
-    // Stacks are MUI components that quickly let you stack nested components horizontally and vertically instead of 
-    //      manually needing to define flex boxes through CSS
-    // Cards are useful as backdrops to make other components stand out
-    // Typography is an alternative component to any built in HTML text component (like H1 or P)
-    //      Side Note: Page scrapers parsing through HTML will often use H1 components to "sum up" what a web page
-    //      represents. If you use H1's through H6's a lot, you may confuse search engines. But we don't have to 
-    //      worry about that.
+    function handleEdit() {
+        editingData ? setEditingData(false) : setEditingData(true)
+    }
+
+    function handleSubmit() {
+        setWeightLiftData(prevData => [
+            ...prevData,
+            {
+                reps: repsIn,
+                sets: setsIn,
+                weightOfWeights: weightOfWeightsIn,
+                duration: durationIn,
+                avgHeartRate: avgHeartRateIn,
+                maxHeartRate: maxHeartRateIn,
+                bodyWeight: bodyWeightIn,
+                fitnessLevel: fitnessLevelIn
+            }
+        ])
+    }
+
+    function handleReset() {
+        setWeightLiftData([])
+    }
+
     return (
         <Stack>
             <Typography fontSize={32}>
@@ -195,7 +164,97 @@ function WeightLiftingMetrics() {
                     />
                 </Card>
             </Stack>
-            <Link to="../fitnessTypes" className="button-link">Back to Fitness Types</Link>
+            {!editingData ? (
+                <></>
+            ) : (
+                <Card sx={{ padding:"40px", backgroundColor:"#828c85"}}>
+                    <Typography marginBottom={5} fontSize={24}>Input Weightlifting Metrics</Typography>
+                    <Stack direction="column" spacing={textInputSpacing}>
+                        <TextField 
+                            required
+                            variant="filled" 
+                            label="Reps"
+                            type="number"
+                            onChange={(e) => setRepsIn(e.target.value)}
+                        />
+                        <TextField 
+                            required
+                            variant="filled" 
+                            label="Sets"
+                            type="number"
+                            onChange={(e) => setSetsIn(e.target.value)}
+                        />
+                        <TextField 
+                            required 
+                            variant="filled" 
+                            label="Weight of Weights"
+                            type="number"
+                            onChange={(e) => setWeightOfWeightsIn(e.target.value)}
+                            InputProps={{ 
+                                endAdornment: <InputAdornment position='end'>Kg</InputAdornment>
+                                }}
+                        />
+                        <TextField 
+                            required 
+                            variant="filled" 
+                            label="Duration"
+                            type="number"
+                            onChange={(e) => setDurationIn(e.target.value)}
+                            InputProps={{ 
+                                endAdornment: <InputAdornment position='end'>Hours</InputAdornment>
+                                }}
+                        />
+                        <TextField 
+                            required 
+                            variant="filled" 
+                            label="Average Heart Rate"
+                            type="number"
+                            onChange={(e) => setAvgHeartRateIn(e.target.value)}
+                        />
+                        <TextField 
+                            required 
+                            variant="filled" 
+                            label="Maximum Heart Rate"
+                            type="number"
+                            onChange={(e) => setMaxHeartRateIn(e.target.value)}
+                        />
+                        <TextField 
+                            required 
+                            variant="filled" 
+                            label="Bodyweight"
+                            type="number"
+                            onChange={(e) => setBodyWeightIn(e.target.value)}
+                            InputProps={{ 
+                                endAdornment: <InputAdornment position='end'>Kg</InputAdornment>
+                                }}
+                        />
+                        <TextField 
+                            required 
+                            variant="filled" 
+                            label="Fitness Level"
+                            type="number"
+                            onChange={(e) => setFitnessLevelIn(e.target.value)}
+                            InputProps={{ 
+                                endAdornment: <InputAdornment position='end'>(0 - 2)</InputAdornment>
+                                }}
+                        />
+                    </Stack>
+
+                    <Stack direction="row" justifyContent="center" spacing={5} marginTop={5}>
+                        <Button variant="contained" onClick={handleSubmit}>Submit</Button>
+                        <Button variant="contained" color="error" onClick={handleReset}>Reset Data</Button>
+                    </Stack>
+                    
+                </Card>
+            )}
+            <Stack direction="row" marginTop={5} spacing={5} justifyContent="center">
+                <Button variant="contained" 
+                    onClick={handleEdit}
+                >
+                    {editingData ? "Stop Editing" : "Edit Data"}
+                </Button>
+                <Link to="../fitnessTypes" className="button-link">Back to Fitness Types</Link>
+            </Stack>
         </Stack>
 
     );


### PR DESCRIPTION
This branch features all behavior needed to input exercise metrics into state. Features include:
- Toggle-able UI for entering data into text fields
- Data validation capabilities, alerting the user of erroneous data
- The option to reset all data entered by the user
- A clear button to quickly clear previously entered data from text fields

Eventually I would like to see all of these individual input fields for each category of physical activity made into their own components so that they can be invoked anywhere in our application (like on the profile page, or in a dedicated input UI)

Of course all of this will need to be hooked up to a database eventually, but the client-side UI is functional. 