### PR TITLE
Usernames are no longer case-sensitive

### DIFF
--- a/client/src/pages/LoginPage.jsx
+++ b/client/src/pages/LoginPage.jsx
@@ -75,7 +75,7 @@ useEffect(() => {
   const handleSubmit = () => {
     // The find method looks through an array until the find condition is fulfilled, then one element
     // gets assigned to the element in which that condition was true
-    const matchingUser = allUsers.find(user => username === user.username && password === user.password);
+    const matchingUser = allUsers.find(user => username.toLowerCase() === user.username.toLowerCase() && password === user.password);
     if (matchingUser) {
       selectUser(matchingUser._id);
       setTheme(matchingUser.lightmodeToggle);


### PR DESCRIPTION
Now you can sign in without having to worry about the capitalization or lack thereof of characters in your username.

For example, if your username is Alex, you can log in by entering "alEX" (or any other combination of lowercase/uppercase) as your username. 

This leads to a better user experience as you don't have to remember the exact capitalization of your username anymore. 